### PR TITLE
[ISSUE-35] Submit post parameters using UTF-8 charset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 1.1.0 (UNRELEASED)
 
+#### Bugfixes
+- [Issue-35](https://github.com/Crim/pardot-java-client/issues/35) Submit POST parameters using UTF-8 charset by default. 
+
 #### Internal Dependency Updates
 - org.apache.httpcomponents:httpclent from 4.5.6 to 4.5.10
 - org.apache.logging.log4j from 2.11.0 to 2.12.1

--- a/src/main/java/com/darksci/pardot/api/rest/HttpClientRestClient.java
+++ b/src/main/java/com/darksci/pardot/api/rest/HttpClientRestClient.java
@@ -42,6 +42,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -196,7 +198,7 @@ public class HttpClientRestClient implements RestClient {
             for (Map.Entry<String, String> entry : postParams.entrySet()) {
                 params.add(new BasicNameValuePair(entry.getKey(), entry.getValue()));
             }
-            post.setEntity(new UrlEncodedFormEntity(params));
+            post.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
 
             logger.info("Executing request {} with {}", post.getRequestLine(), filterSensitiveParams(params));
 


### PR DESCRIPTION
Bugfix for #35  

Sets Post Parameter charset to UTF-8 by default.