### PR TITLE
improve support for record multiple value custom fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.0 (03/05/2020)
+- [ISSUE-102]() Improve support for record multiple fields. 
+
+### Breaking Change
+
+
 ## 1.1.2 (02/20/2020)
 #### Bugfixes
 - [ISSUE-45](https://github.com/Crim/pardot-java-client/issues/45) Fixed bug preventing the library from auto-renewing a session when it expires.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 2.0.0 (03/05/2020)
-- [ISSUE-102](https://github.com/Crim/pardot-java-client/pull/52) Improve support for record multiple fields. 
+- [ISSUE-50](https://github.com/Crim/pardot-java-client/issues/50) Improve support for record multiple fields. 
 
 ### Breaking Change
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 2.0.0 (03/05/2020)
-- [ISSUE-102]() Improve support for record multiple fields. 
+- [ISSUE-102](https://github.com/Crim/pardot-java-client/pull/52) Improve support for record multiple fields. 
 
 ### Breaking Change
+
+In order to better support record multiple value custom fields, the accessor on `Prospect` for `getCustomFields()` has been changed **FROM**  
+`public Map<String, String> getCustomFields()` **TO** `public Map<String, ProspectCustomFieldValue> getCustomFields()`
+
+For custom fields which are NOT record multiple value custom fields the accessor `public String getCustomField(final String customFieldName)` method will continue to return the stored value for the custom field.
+
+For custom fields which ARE record multiple value custom fields the accessor `public String getCustomField(final String customFieldName)` method will only return the first stored value.  You can use the new accessor 
+`public List<String> getCustomFieldValues(final String customFieldName)` to get all stored values for record multiple value custom fields.  
 
 
 ## 1.1.2 (02/20/2020)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This client library is released on Maven Central.  Add a new dependency to your 
 <dependency>
     <groupId>com.darksci</groupId>
     <artifactId>pardot-api-client</artifactId>
-    <version>1.1.2</version>
+    <version>2.0.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.darksci</groupId>
     <artifactId>pardot-api-client</artifactId>
-    <version>1.1.2</version>
+    <version>2.0.0</version>
     <packaging>jar</packaging>
 
     <!-- Require Maven 3.5.0 -->

--- a/src/main/java/com/darksci/pardot/api/parser/JacksonFactory.java
+++ b/src/main/java/com/darksci/pardot/api/parser/JacksonFactory.java
@@ -17,6 +17,8 @@
 
 package com.darksci.pardot.api.parser;
 
+import com.darksci.pardot.api.parser.prospect.ProspectCustomFieldDeserializer;
+import com.darksci.pardot.api.response.customfield.ProspectCustomFieldValue;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule;
@@ -31,14 +33,25 @@ import java.text.SimpleDateFormat;
 public class JacksonFactory {
 
     /**
+     * Cache mapper instance.
+     */
+    private static final XmlMapper instance = newInstance();
+
+    /**
      * Creates properly configured Jackson XML Mapper instances.
      * @return XmlMapper instance.
      */
     public static XmlMapper newInstance() {
+        if (instance != null) {
+            return instance;
+        }
+
         // Create new mapper
         final JacksonXmlModule module = new JacksonXmlModule();
         module.setDefaultUseWrapper(false);
-        XmlMapper mapper = new XmlMapper(module);
+        module.addDeserializer(ProspectCustomFieldValue.class, new ProspectCustomFieldDeserializer());
+
+        final XmlMapper mapper = new XmlMapper(module);
 
         // Configure it
         mapper

--- a/src/main/java/com/darksci/pardot/api/parser/prospect/ProspectCustomFieldDeserializer.java
+++ b/src/main/java/com/darksci/pardot/api/parser/prospect/ProspectCustomFieldDeserializer.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2017, 2018, 2019, 2020 Stephen Powis https://github.com/Crim/pardot-java-client
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.darksci.pardot.api.parser.prospect;
+
+import com.darksci.pardot.api.response.customfield.ProspectCustomFieldValue;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Custom deserializer to be able to support Record Multiple custom fields.
+ */
+public class ProspectCustomFieldDeserializer extends StdDeserializer<ProspectCustomFieldValue> {
+
+    /**
+     * Constructor.
+     */
+    public ProspectCustomFieldDeserializer() {
+        this(null);
+    }
+
+    /**
+     * Constructor.
+     * @param vc the type of the class this handles.
+     */
+    public ProspectCustomFieldDeserializer(final Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public ProspectCustomFieldValue deserialize(final JsonParser parser, final DeserializationContext context) throws IOException {
+        // Get the current custom field name.
+        final String fieldName = parser.getCurrentName();
+
+        // Keep track of all the values associated with the field.
+        final List<String> fieldValues = new ArrayList<>();
+
+        // If we have multiple values
+        if (parser.getCurrentToken() == JsonToken.START_OBJECT) {
+            // Loop until we hit end object
+            while (parser.nextToken() != JsonToken.END_OBJECT) {
+                // Pull out each value
+                if (parser.getCurrentToken() == JsonToken.VALUE_STRING) {
+                    fieldValues.add(parser.getValueAsString());
+                }
+            }
+        } else if (parser.getCurrentToken() == JsonToken.VALUE_STRING) {
+            // If we have a single value, we just record the value as is.
+            fieldValues.add(parser.getValueAsString());
+        }
+
+        // Return our deserialized instance.
+        return new ProspectCustomFieldValue(fieldName, fieldValues);
+    }
+}

--- a/src/main/java/com/darksci/pardot/api/request/prospect/ProspectModifyRequest.java
+++ b/src/main/java/com/darksci/pardot/api/request/prospect/ProspectModifyRequest.java
@@ -18,6 +18,7 @@
 package com.darksci.pardot.api.request.prospect;
 
 import com.darksci.pardot.api.request.BaseRequest;
+import com.darksci.pardot.api.response.customfield.ProspectCustomFieldValue;
 import com.darksci.pardot.api.response.prospect.Prospect;
 
 import java.util.Map;
@@ -65,8 +66,18 @@ abstract class ProspectModifyRequest<T> extends BaseRequest<T> {
 
         // Loop through and set custom fields
         if (prospect.getCustomFields() != null) {
-            for (Map.Entry<String, Object> entry: prospect.getCustomFields().entrySet()) {
-                setParam(entry.getKey(), entry.getValue());
+            for (ProspectCustomFieldValue customFieldValue : prospect.getCustomFields().values()) {
+                // For single value custom fields.
+                if (!customFieldValue.hasMultipleValues()) {
+                    setParam(customFieldValue.getFieldName(), customFieldValue.getValue());
+                } else {
+                    // For multiple value fields, send as field_name_<index> = value
+                    int fieldIndex = 0;
+                    for (final String value : customFieldValue.getValues()) {
+                        setParam(customFieldValue.getFieldName() + "_" + fieldIndex, value);
+                        fieldIndex++;
+                    }
+                }
             }
         }
 

--- a/src/main/java/com/darksci/pardot/api/request/prospect/ProspectModifyRequest.java
+++ b/src/main/java/com/darksci/pardot/api/request/prospect/ProspectModifyRequest.java
@@ -65,7 +65,7 @@ abstract class ProspectModifyRequest<T> extends BaseRequest<T> {
 
         // Loop through and set custom fields
         if (prospect.getCustomFields() != null) {
-            for (Map.Entry<String, String> entry: prospect.getCustomFields().entrySet()) {
+            for (Map.Entry<String, Object> entry: prospect.getCustomFields().entrySet()) {
                 setParam(entry.getKey(), entry.getValue());
             }
         }

--- a/src/main/java/com/darksci/pardot/api/response/customfield/ProspectCustomFieldValue.java
+++ b/src/main/java/com/darksci/pardot/api/response/customfield/ProspectCustomFieldValue.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2017, 2018, 2019, 2020 Stephen Powis https://github.com/Crim/pardot-java-client
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.darksci.pardot.api.response.customfield;
+
+import com.darksci.pardot.api.parser.prospect.ProspectCustomFieldDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Represents a Prospect CustomField value.
+ * Since custom fields can be stored as a single value, or as a list of values (for record multiple fields),
+ * this attempts to normalize the way these two types are accessed.
+ */
+@JsonDeserialize(using = ProspectCustomFieldDeserializer.class)
+public class ProspectCustomFieldValue {
+    private final String fieldName;
+    private final List<String> values = new ArrayList<>();
+
+    /**
+     * Constructor for custom field which only has a single value.
+     * @param fieldName name of the field.
+     * @param value value of the field.
+     */
+    public ProspectCustomFieldValue(final String fieldName, final String value) {
+        this.fieldName = fieldName;
+        if (value != null) {
+            this.values.add(value);
+        }
+    }
+
+    /**
+     * Constructor for custom field which has multiple values.
+     * @param fieldName name of the field.
+     * @param values values for the field.
+     */
+    public ProspectCustomFieldValue(final String fieldName, final Collection<String> values) {
+        this.fieldName = fieldName;
+        if (values != null) {
+            this.values.addAll(values);
+        }
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    /**
+     * The value of the custom field.
+     * @return value of the custom field.
+     *         *NOTE* If this is a record multiple field with multiple values, this will return the first value only.
+     */
+    public String getValue() {
+        if (values.isEmpty()) {
+            return null;
+        }
+        return values.get(0);
+    }
+
+    public List<String> getValues() {
+        return values;
+    }
+
+    public boolean hasMultipleValues() {
+        return getValues().size() > 1;
+    }
+
+    public void addValue(final String value) {
+        values.add(value);
+    }
+
+    public void addValues(final Collection<String> values) {
+        values.addAll(values);
+    }
+
+    public void setValue(final String value) {
+        values.clear();
+        addValue(value);
+    }
+
+    public void setValues(final Collection<String> values) {
+        values.clear();
+        addValues(values);
+    }
+
+    @Override
+    public String toString() {
+        return "ProspectCustomFieldValue{"
+            + "fieldName='" + fieldName + '\''
+            + ", values=" + values
+            + '}';
+    }
+}

--- a/src/main/java/com/darksci/pardot/api/response/prospect/Prospect.java
+++ b/src/main/java/com/darksci/pardot/api/response/prospect/Prospect.java
@@ -17,6 +17,7 @@
 
 package com.darksci.pardot.api.response.prospect;
 
+import com.darksci.pardot.api.ParserException;
 import com.darksci.pardot.api.parser.PardotBooleanSerializer;
 import com.darksci.pardot.api.response.campaign.Campaign;
 import com.darksci.pardot.api.response.list.ListSubscription;
@@ -122,7 +123,7 @@ public class Prospect {
     private LastActivity lastActivity;
 
     // Custom fields
-    private Map<String, String> customFields = new HashMap<>();
+    private Map<String, Object> customFields = new HashMap<>();
 
     // Related Objects
     private Campaign campaign;
@@ -347,7 +348,7 @@ public class Prospect {
 
     // Custom fields
     @JsonAnyGetter
-    public Map<String, String> getCustomFields() {
+    public Map<String, Object> getCustomFields() {
         return customFields;
     }
 
@@ -358,11 +359,15 @@ public class Prospect {
      * @return Value of the custom field.
      */
     public String getCustomField(final String customFieldName) {
-        return getCustomFields().get(customFieldName);
+        return String.valueOf(customFields.get(customFieldName));
+    }
+
+    public Map<String, String> getCustomFieldValues(final String customFieldName) {
+        return (Map<String, String>) customFields.get(customFieldName);
     }
 
     @JsonAnySetter
-    public void setCustomField(final String fieldName, final String fieldValue) {
+    public void setCustomField(final String fieldName, final Object fieldValue) {
         customFields.put(fieldName, fieldValue);
     }
 

--- a/src/test/java/com/darksci/pardot/api/PardotClientIntegrationTest.java
+++ b/src/test/java/com/darksci/pardot/api/PardotClientIntegrationTest.java
@@ -128,6 +128,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
@@ -1064,6 +1067,14 @@ public class PardotClientIntegrationTest {
         prospect.setFirstName("Test");
         prospect.setLastName("User");
         prospect.setCity("Some City");
+
+        java.util.List<String> values = new ArrayList<>();
+        values.add("val1");
+        values.add("val2");
+        Map<String, Object> customFields = new HashMap<>();
+        customFields.put("custom", values);
+
+        prospect.setCustomField("custom", customFields);
 
         final ProspectUpsertRequest request = new ProspectUpsertRequest()
             .withProspect(prospect);

--- a/src/test/java/com/darksci/pardot/api/PardotClientIntegrationTest.java
+++ b/src/test/java/com/darksci/pardot/api/PardotClientIntegrationTest.java
@@ -128,6 +128,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/darksci/pardot/api/parser/prospect/ProspectReadResponseParserTest.java
+++ b/src/test/java/com/darksci/pardot/api/parser/prospect/ProspectReadResponseParserTest.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class ProspectReadResponseParserTest extends BaseResponseParserTest {
     private static final Logger logger = LoggerFactory.getLogger(ProspectReadResponseParserTest.class);
@@ -75,10 +76,20 @@ public class ProspectReadResponseParserTest extends BaseResponseParserTest {
         // Validate custom fields
         assertNotNull("Should have non-null custom fields", prospect.getCustomFields());
         assertEquals("Should have 3 custom fields", 3, prospect.getCustomFields().size());
+
+        assertTrue("Should have custom field", prospect.hasCustomField("MyCustom_Field"));
         assertEquals("Should have first custom field value", "my custom field value", prospect.getCustomField("MyCustom_Field"));
+        assertTrue("Should have custom field", prospect.hasCustomField("MyOtherCustom_Field"));
         assertEquals("Should have second custom field value", "my other custom field value", prospect.getCustomField("MyOtherCustom_Field"));
-        assertEquals("Should have object custom field value", "{value=abc}", prospect.getCustomField("Add_Prospect01"));
-        assertEquals("Should have object custom field values", "abc", prospect.getCustomFieldValues("Add_Prospect01").get("value"));
+
+        // Check MultiSelectField
+        assertTrue("Should have custom field", prospect.hasCustomField("CustomMultiSelectField"));
+        assertEquals("First value should be returned when calling getCustomField()", "value0", prospect.getCustomField("CustomMultiSelectField"));
+
+        assertEquals("Should have 3 values", 3, prospect.getCustomFieldValues("CustomMultiSelectField").size());
+        assertEquals("Should have first value", "value0", prospect.getCustomFieldValues("CustomMultiSelectField").get(0));
+        assertEquals("Should have second value", "value1", prospect.getCustomFieldValues("CustomMultiSelectField").get(1));
+        assertEquals("Should have third value", "value2", prospect.getCustomFieldValues("CustomMultiSelectField").get(2));
 
         // Validate assigned To user
         assertNotNull("Assigned To is not null", prospect.getAssignedTo());

--- a/src/test/java/com/darksci/pardot/api/parser/prospect/ProspectReadResponseParserTest.java
+++ b/src/test/java/com/darksci/pardot/api/parser/prospect/ProspectReadResponseParserTest.java
@@ -74,9 +74,11 @@ public class ProspectReadResponseParserTest extends BaseResponseParserTest {
 
         // Validate custom fields
         assertNotNull("Should have non-null custom fields", prospect.getCustomFields());
-        assertEquals("Should have 2 custom fields", 2, prospect.getCustomFields().size());
+        assertEquals("Should have 3 custom fields", 3, prospect.getCustomFields().size());
         assertEquals("Should have first custom field value", "my custom field value", prospect.getCustomField("MyCustom_Field"));
         assertEquals("Should have second custom field value", "my other custom field value", prospect.getCustomField("MyOtherCustom_Field"));
+        assertEquals("Should have object custom field value", "{value=abc}", prospect.getCustomField("Add_Prospect01"));
+        assertEquals("Should have object custom field values", "abc", prospect.getCustomFieldValues("Add_Prospect01").get("value"));
 
         // Validate assigned To user
         assertNotNull("Assigned To is not null", prospect.getAssignedTo());

--- a/src/test/resources/mockResponses/prospectRead.xml
+++ b/src/test/resources/mockResponses/prospectRead.xml
@@ -46,9 +46,11 @@
         <is_starred></is_starred>
         <created_at>2017-08-11 21:40:25</created_at>
         <updated_at>2017-08-11 21:40:25</updated_at>
-        <Add_Prospect01>
-            <value>abc</value>
-        </Add_Prospect01>
+        <CustomMultiSelectField>
+            <value>value0</value>
+            <value>value1</value>
+            <value>value2</value>
+        </CustomMultiSelectField>
         <campaign>
             <id>423</id>
             <name>Website Tracking</name>

--- a/src/test/resources/mockResponses/prospectRead.xml
+++ b/src/test/resources/mockResponses/prospectRead.xml
@@ -46,6 +46,9 @@
         <is_starred></is_starred>
         <created_at>2017-08-11 21:40:25</created_at>
         <updated_at>2017-08-11 21:40:25</updated_at>
+        <Add_Prospect01>
+            <value>abc</value>
+        </Add_Prospect01>
         <campaign>
             <id>423</id>
             <name>Website Tracking</name>


### PR DESCRIPTION
fix for #50 

## 2.0.0 (03/05/2020)

    ISSUE-102 Improve support for record multiple fields.

Breaking Change

In order to better support record multiple value custom fields, the accessor on Prospect for getCustomFields() has been changed FROM
public Map<String, String> getCustomFields() TO public Map<String, ProspectCustomFieldValue> getCustomFields()

For custom fields which are NOT record multiple value custom fields the accessor public String getCustomField(final String customFieldName) method will continue to return the stored value for the custom field.

For custom fields which ARE record multiple value custom fields the accessor public String getCustomField(final String customFieldName) method will only return the first stored value. You can use the new accessor public List<String> getCustomFieldValues(final String customFieldName) to get all stored values for record multiple value custom fields.