### PR TITLE
Add missing query parameters to ProspectQueryRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 3.0.0 (UNRELEASED)
+## 3.1.0 (10/23/2020)
+- [ISSUE-65](https://github.com/Crim/pardot-java-client/issues/65) Adds missing Query options to `ProspectQuerytRequest` for `withUpdatedAfter()` and `withUpdatedBefore()`.
+
+## 3.0.0 (09/21/2020)
 
 ### Breaking Changes
 This release has several breaking changes. See [3.0.0 Migration Notes](3_0_0_migration_notes.MD) for details on breaking changes and how to upgrade.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.darksci</groupId>
     <artifactId>pardot-api-client</artifactId>
-    <version>3.0.0</version>
+    <version>3.1.0</version>
     <packaging>jar</packaging>
 
     <!-- Require Maven 3.5.0 -->

--- a/src/main/java/com/darksci/pardot/api/request/BaseQueryRequest.java
+++ b/src/main/java/com/darksci/pardot/api/request/BaseQueryRequest.java
@@ -63,6 +63,7 @@ public abstract class BaseQueryRequest<T> extends BaseRequest<T> {
 
     /**
      * Add constraint where UpdatedAt field is after than the specified time value.
+     * Note: marked as protected because not supported by all entities.
      * @param updatedAfter date constraint.
      * @return BaseQueryRequest
      */
@@ -72,6 +73,7 @@ public abstract class BaseQueryRequest<T> extends BaseRequest<T> {
 
     /**
      * Add constraint where UpdatedAt field is before than the specified time value.
+     * Note: marked as protected because not supported by all entities.
      * @param updatedBefore date constraint.
      * @return BaseQueryRequest
      */

--- a/src/main/java/com/darksci/pardot/api/request/prospect/ProspectQueryRequest.java
+++ b/src/main/java/com/darksci/pardot/api/request/prospect/ProspectQueryRequest.java
@@ -43,7 +43,7 @@ public class ProspectQueryRequest extends BaseQueryRequest<ProspectQueryRequest>
      * @param fields Collection of fields to be selected by the request.
      * @return RequestBuilder
      */
-    public ProspectQueryRequest withFields(Collection<String> fields) {
+    public ProspectQueryRequest withFields(final Collection<String> fields) {
         final String fieldsStr = fields.stream().collect(Collectors.joining( "," ));
         final String currentValue = getParam("fields");
         if (currentValue == null) {
@@ -127,6 +127,16 @@ public class ProspectQueryRequest extends BaseQueryRequest<ProspectQueryRequest>
     }
 
     /**
+     * Retrieve only archived/non-archived prospects.
+     * @param onlyReturnArchived True to only get returned archived entries.
+     * @return BaseQueryRequest
+     */
+    @Override
+    public ProspectQueryRequest withArchivedOnly(final boolean onlyReturnArchived) {
+        return super.withArchivedOnly(onlyReturnArchived);
+    }
+
+    /**
      * Only select prospects who have a grade equal to the specified grade.
      * @param grade Grade in format of "A", "A+", "B", "C-"
      * @return RequestBuilder
@@ -174,8 +184,28 @@ public class ProspectQueryRequest extends BaseQueryRequest<ProspectQueryRequest>
      * @param lastActivityAfter The date to filter.
      * @return RequestBuilder
      */
-    public ProspectQueryRequest withLastActivityAfter(DateParameter lastActivityAfter) {
+    public ProspectQueryRequest withLastActivityAfter(final DateParameter lastActivityAfter) {
         return setParam("last_activity_after", lastActivityAfter);
+    }
+
+    /**
+     * Add constraint where UpdatedAt field is after than the specified time value.
+     * @param updatedAfter date constraint.
+     * @return BaseQueryRequest
+     */
+    @Override
+    public ProspectQueryRequest withUpdatedAfter(final DateParameter updatedAfter) {
+        return super.withUpdatedAfter(updatedAfter);
+    }
+
+    /**
+     * Add constraint where UpdatedAt field is before than the specified time value.
+     * @param updatedBefore date constraint.
+     * @return BaseQueryRequest
+     */
+    @Override
+    public ProspectQueryRequest withUpdatedBefore(final DateParameter updatedBefore) {
+        return super.withUpdatedBefore(updatedBefore);
     }
 
     /**
@@ -279,5 +309,4 @@ public class ProspectQueryRequest extends BaseQueryRequest<ProspectQueryRequest>
     public ProspectQueryRequest withSortById() {
         return super.withSortById();
     }
-
 }


### PR DESCRIPTION
Adds missing query options to ProspectQueryRequest for updatedAfter and updatedBefore