### PR TITLE
Resolve remaining compatibility issues required to upgrade jackson

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,44 @@
+name: CI Test Suite
+
+# Triggers the workflow on pull requests, manually, or pushes to master
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      ## Run tests against Open JDK8
+      - uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 8
+
+      ## Cache maven dependencies
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      ## Run CheckStyle and License Header checks, compile, and install locally
+      - name: Run checkstyle, license check, compile and install locally
+        run: mvn clean install -DskipTests=true -DskipCheckStyle=false -Dmaven.javadoc.skip=true -B -V
+
+      ## Run test suite
+      - name: Run test suite
+        run: mvn test -B -DskipCheckStyle=true -Dmaven.javadoc.skip=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: java
-sudo: false
-jdk:
-  - openjdk8
-cache:
-  directories:
-  - $HOME/.m2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.0.1 (UNRELEASED)
+#### Internal Dependency Updates
+- Upgraded Jackson from version 2.11.4 to 2.13.1.
+
+
 ## 4.0.0 (06/03/2021)
 
 ### NOTE: Breaking Change

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Pardot Java API Client
 
-[![Build Status](https://travis-ci.org/Crim/pardot-java-client.svg?branch=master)](https://travis-ci.org/Crim/pardot-java-client)
-
 ## What is it? 
 
 This library is a fluent style API client for Pardot's API (version 3 and 4).

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.darksci</groupId>
     <artifactId>pardot-api-client</artifactId>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
     <packaging>jar</packaging>
 
     <!-- Require Maven 3.5.0 -->
@@ -47,7 +47,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Jackson version -->
-        <jackson.version>2.11.4</jackson.version>
+        <jackson.version>2.13.1</jackson.version>
 
         <!-- Define which version of junit you'll be running -->
         <junit.version>4.13.2</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -237,18 +237,9 @@
                 <version>3.0</version>
                 <configuration>
                     <header>LICENSE.txt</header>
-                    <excludes>
-                        <exclude>**/.md</exclude>
-                        <exclude>**.MD</exclude>
-                        <exclude>**/.bak</exclude>
-                        <exclude>**.yml</exclude>
-                        <exclude>**.yaml</exclude>
-                        <exclude>**.xml</exclude>
-                        <exclude>build/**</exclude>
-                        <exclude>src/test/resources/**</exclude>
-                        <exclude>src/main/resources/**</exclude>
-                        <exclude>LICENSE.txt</exclude>
-                    </excludes>
+                    <includes>
+                        <include>**/**.java</include>
+                    </includes>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/com/darksci/pardot/api/parser/JacksonFactory.java
+++ b/src/main/java/com/darksci/pardot/api/parser/JacksonFactory.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.deser.FromXmlParser;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 
 import java.text.SimpleDateFormat;
@@ -66,6 +67,8 @@ public class JacksonFactory {
         module.addDeserializer(ProspectCustomFieldValue.class, new ProspectCustomFieldDeserializer());
 
         final XmlMapper mapper = new XmlMapper(module);
+        // Coerce fields marked as <fieldName/> into NULL to maintain backwards compatibility.
+        mapper.enable(FromXmlParser.Feature.EMPTY_ELEMENT_AS_NULL);
 
         // Configure it
         mapper

--- a/src/test/java/com/darksci/pardot/api/parser/list/ListReadResponseParserTest.java
+++ b/src/test/java/com/darksci/pardot/api/parser/list/ListReadResponseParserTest.java
@@ -46,8 +46,10 @@ public class ListReadResponseParserTest extends BaseResponseParserTest {
         assertEquals("Has correct name", "Stevie Only List", list.getName());
         assertEquals("Has correct isPublic", false, list.getIsPublic());
         assertEquals("Has correct isDynamic", false, list.getIsDynamic());
+        // tags like <title/> should be null
         assertNull("Has correct title", list.getTitle());
-        assertNull("Has correct description", list.getDescription());
+        // tags like <description></description> should be empty string
+        assertEquals("Has correct description", "", list.getDescription());
         assertEquals("Has correct isCrmVisible", false, list.getIsCrmVisible());
         assertEquals("Has correct createdAt", "2017-08-11T22:03:22.000", list.getCreatedAt().toString());
         assertEquals("Has correct updatedAt", "2017-08-11T22:03:22.000", list.getUpdatedAt().toString());

--- a/src/test/resources/mockResponses/listRead.xml
+++ b/src/test/resources/mockResponses/listRead.xml
@@ -6,7 +6,7 @@
         <is_public>false</is_public>
         <is_dynamic>false</is_dynamic>
         <title/>
-        <description/>
+        <description></description>
         <is_crm_visible>false</is_crm_visible>
         <created_at>2017-08-11 22:03:22</created_at>
         <updated_at>2017-08-11 22:03:22</updated_at>


### PR DESCRIPTION
There was a breaking change between jackson 2.11.x and 2.12.x which changed on parsing of XML was done for tags like `<title/>`.

Previously this would be parsed as `null`, but after 2.12.x it would be parsed as empty string `""`.

In order to maintain correct backwards compatibility for this library, and continue to properly parse the values, jackson's mapping configuration was updated to ensure the correct parsing behavior for Pardots API.